### PR TITLE
test: Fill generator tests, parametrize inspectors/llm, add pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,14 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+addopts = "--tb=short"
+markers = [
+    "unit: fast, isolated unit tests with no external I/O",
+    "integration: end-to-end workflow tests that may touch the filesystem or network",
+    "slow: tests that take more than 1 second to run",
+]
+filterwarnings = [
+    "ignore::DeprecationWarning:pydantic",
+    "ignore::FutureWarning:transformers",
+    "ignore::UserWarning:sentence_transformers",
+]

--- a/tests/generator/test_generator.py
+++ b/tests/generator/test_generator.py
@@ -1,0 +1,486 @@
+"""
+Tests for maposcal.generator.control_mapper and maposcal.generator.security_section_mapper.
+
+Covers:
+- parse_llm_response: JSON extraction from raw LLM output
+- security_section_mapper: pure helper functions (no I/O)
+- get_relevant_chunks: FAISS-backed retrieval (mocked)
+- map_control: end-to-end control generation (mocked LLM + chunks)
+"""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+from maposcal.generator.control_mapper import (
+    parse_llm_response,
+    get_relevant_chunks,
+    map_control,
+    validate_content_quality,
+)
+from maposcal.generator.security_section_mapper import (
+    get_control_family,
+    get_relevant_security_sections,
+    parse_security_overview_sections,
+    build_selective_security_overview_section,
+    validate_security_overview_structure,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / shared test data
+# ---------------------------------------------------------------------------
+
+VALID_LLM_CONTENT = {
+    "control-status": "applicable and inherently satisfied",
+    "control-explanation": "The system implements access control through authentication mechanisms.",
+    "control-configuration": [],
+    "statement-description": "Access control is implemented through role-based authentication.",
+}
+
+SAMPLE_CONTROL_DICT = {
+    "id": "AC-1",
+    "title": "Access Control Policy and Procedures",
+    "statement": "The organization develops, documents, and disseminates an access control policy.",
+}
+
+SAMPLE_SECURITY_OVERVIEW = """\
+# Service Overview
+This service is a REST API for user management.
+
+## Authentication and Authorization
+OAuth 2.0 with JWT tokens is used for all endpoints.
+
+## Encryption and Data Protection
+All data at rest is encrypted with AES-256.
+
+## Audit Logging and Monitoring
+All authentication events are logged to CloudWatch.
+"""
+
+
+# ---------------------------------------------------------------------------
+# A. parse_llm_response
+# ---------------------------------------------------------------------------
+
+class TestParseLlmResponse:
+    """parse_llm_response extracts JSON from various LLM output formats."""
+
+    @pytest.mark.parametrize("raw,expected", [
+        # Markdown fenced block with json label
+        (
+            '```json\n{"key": "value"}\n```',
+            {"key": "value"},
+        ),
+        # Markdown fenced block without label
+        (
+            '```\n{"key": "value"}\n```',
+            {"key": "value"},
+        ),
+        # Plain JSON string
+        (
+            '{"key": "value"}',
+            {"key": "value"},
+        ),
+        # JSON with leading/trailing whitespace
+        (
+            '  {"key": "value"}  ',
+            {"key": "value"},
+        ),
+        # Extra prose before and after fenced block
+        (
+            'Here is the result:\n```json\n{"key": "value"}\n```\nDone.',
+            {"key": "value"},
+        ),
+        # Nested JSON object
+        (
+            '{"outer": {"inner": 1}}',
+            {"outer": {"inner": 1}},
+        ),
+    ])
+    @pytest.mark.unit
+    def test_parse_valid_json(self, raw, expected):
+        assert parse_llm_response(raw) == expected
+
+    @pytest.mark.unit
+    def test_parse_malformed_json_returns_raw_key(self):
+        result = parse_llm_response("not valid json at all")
+        assert "llm_raw_response" in result
+
+    @pytest.mark.unit
+    def test_parse_empty_string_returns_raw_key(self):
+        result = parse_llm_response("")
+        assert "llm_raw_response" in result
+
+    @pytest.mark.unit
+    def test_parse_realistic_control_json(self):
+        raw = json.dumps(VALID_LLM_CONTENT)
+        result = parse_llm_response(raw)
+        assert result["control-status"] == "applicable and inherently satisfied"
+        assert "control-explanation" in result
+
+
+# ---------------------------------------------------------------------------
+# B. security_section_mapper — pure functions
+# ---------------------------------------------------------------------------
+
+class TestGetControlFamily:
+    """get_control_family extracts the family prefix from a NIST control ID."""
+
+    @pytest.mark.parametrize("control_id,expected", [
+        ("AC-1", "AC"),
+        ("SC-28", "SC"),
+        ("AU-2", "AU"),
+        ("IA-5", "IA"),
+        ("CM-6", "CM"),
+    ])
+    @pytest.mark.unit
+    def test_standard_control_ids(self, control_id, expected):
+        assert get_control_family(control_id) == expected
+
+    @pytest.mark.unit
+    def test_empty_string_returns_default(self):
+        assert get_control_family("") == "DEFAULT"
+
+    @pytest.mark.unit
+    def test_none_returns_default(self):
+        assert get_control_family(None) == "DEFAULT"
+
+    @pytest.mark.unit
+    def test_no_hyphen_returns_full_string_uppercased(self):
+        # "NOHYPHEN" has no hyphen, so split("-")[0] == "NOHYPHEN"
+        assert get_control_family("nohyphen") == "NOHYPHEN"
+
+
+class TestGetRelevantSecuritySections:
+    """get_relevant_security_sections maps a control ID to section keys."""
+
+    @pytest.mark.parametrize("control_id,expected_sections", [
+        ("AC-1", ["service_overview", "authentication_authorization"]),
+        ("AU-2", ["service_overview", "audit_logging_monitoring"]),
+        ("SC-8", ["service_overview", "encryption_data_protection"]),
+        ("IA-5", ["service_overview", "authentication_authorization"]),
+    ])
+    @pytest.mark.unit
+    def test_known_families(self, control_id, expected_sections):
+        sections = get_relevant_security_sections(control_id)
+        assert sections == expected_sections
+
+    @pytest.mark.unit
+    def test_unknown_family_returns_service_overview(self):
+        # Any family not in the map falls back to DEFAULT → ["service_overview"]
+        sections = get_relevant_security_sections("ZZ-99")
+        assert "service_overview" in sections
+
+
+class TestParseSecurityOverviewSections:
+    """parse_security_overview_sections splits markdown into a section dict."""
+
+    @pytest.mark.unit
+    def test_parses_all_four_sections(self):
+        result = parse_security_overview_sections(SAMPLE_SECURITY_OVERVIEW)
+        assert "service_overview" in result
+        assert "authentication_authorization" in result
+        assert "encryption_data_protection" in result
+        assert "audit_logging_monitoring" in result
+
+    @pytest.mark.unit
+    def test_section_content_contains_header(self):
+        result = parse_security_overview_sections(SAMPLE_SECURITY_OVERVIEW)
+        assert "Service Overview" in result["service_overview"]
+        assert "OAuth 2.0" in result["authentication_authorization"]
+
+    @pytest.mark.unit
+    def test_empty_string_returns_empty_dict(self):
+        assert parse_security_overview_sections("") == {}
+
+    @pytest.mark.unit
+    def test_none_returns_empty_dict(self):
+        assert parse_security_overview_sections(None) == {}
+
+
+class TestBuildSelectiveSecurityOverviewSection:
+    """build_selective_security_overview_section returns focused context strings."""
+
+    @pytest.mark.unit
+    def test_returns_relevant_sections_for_ac_control(self):
+        sections = parse_security_overview_sections(SAMPLE_SECURITY_OVERVIEW)
+        result = build_selective_security_overview_section("AC-1", sections)
+        assert "Service Overview" in result
+        assert "Authentication" in result
+        # Encryption section should NOT be included for AC-1
+        assert "Encryption" not in result
+
+    @pytest.mark.unit
+    def test_returns_empty_string_when_no_sections(self):
+        result = build_selective_security_overview_section("AC-1", {})
+        assert result == ""
+
+    @pytest.mark.unit
+    def test_returns_formatted_header(self):
+        sections = parse_security_overview_sections(SAMPLE_SECURITY_OVERVIEW)
+        result = build_selective_security_overview_section("AC-1", sections)
+        assert "SERVICE SECURITY OVERVIEW" in result
+
+    @pytest.mark.unit
+    def test_missing_section_key_handled_gracefully(self):
+        # Only one section present; missing sections are silently skipped
+        sections = {"service_overview": "# Service Overview\nBasic info."}
+        result = build_selective_security_overview_section("AC-1", sections)
+        # Should still include the service_overview fallback without raising
+        assert isinstance(result, str)
+
+
+class TestValidateSecurityOverviewStructure:
+    """validate_security_overview_structure checks that all required sections exist."""
+
+    @pytest.mark.unit
+    def test_valid_structure_returns_true_no_issues(self):
+        is_valid, issues = validate_security_overview_structure(SAMPLE_SECURITY_OVERVIEW)
+        assert is_valid is True
+        assert issues == []
+
+    @pytest.mark.unit
+    def test_empty_content_returns_false(self):
+        is_valid, issues = validate_security_overview_structure("")
+        assert is_valid is False
+        assert len(issues) > 0
+
+    @pytest.mark.unit
+    def test_missing_sections_reported(self):
+        # Only service overview present — three sections missing
+        partial = "# Service Overview\nJust this section."
+        is_valid, issues = validate_security_overview_structure(partial)
+        assert is_valid is False
+        missing_issues = [i for i in issues if "Missing section" in i]
+        assert len(missing_issues) >= 3
+
+    @pytest.mark.unit
+    def test_none_returns_false(self):
+        is_valid, issues = validate_security_overview_structure(None)
+        assert is_valid is False
+
+
+# ---------------------------------------------------------------------------
+# C. validate_content_quality — pure function
+# ---------------------------------------------------------------------------
+
+class TestValidateContentQuality:
+    """validate_content_quality checks LLM-generated content fields."""
+
+    @pytest.mark.unit
+    def test_valid_content_passes(self):
+        is_valid, issues = validate_content_quality(VALID_LLM_CONTENT)
+        assert is_valid is True
+        assert issues == []
+
+    @pytest.mark.unit
+    def test_missing_control_status_fails(self):
+        content = {**VALID_LLM_CONTENT, "control-status": ""}
+        is_valid, issues = validate_content_quality(content)
+        assert is_valid is False
+        assert any("control-status" in i for i in issues)
+
+    @pytest.mark.unit
+    def test_invalid_control_status_fails(self):
+        content = {**VALID_LLM_CONTENT, "control-status": "not a valid status"}
+        is_valid, issues = validate_content_quality(content)
+        assert is_valid is False
+        assert any("Invalid control-status" in i for i in issues)
+
+    @pytest.mark.unit
+    def test_short_explanation_fails(self):
+        content = {**VALID_LLM_CONTENT, "control-explanation": "short"}
+        is_valid, issues = validate_content_quality(content)
+        assert is_valid is False
+        assert any("explanation" in i.lower() for i in issues)
+
+    @pytest.mark.unit
+    def test_configuration_status_without_config_fails(self):
+        content = {
+            **VALID_LLM_CONTENT,
+            "control-status": "applicable but only satisfied through configuration",
+            "control-configuration": [],
+        }
+        is_valid, issues = validate_content_quality(content)
+        assert is_valid is False
+        assert any("configuration" in i.lower() for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# D. get_relevant_chunks — mocked FAISS/embedder
+# ---------------------------------------------------------------------------
+
+class TestGetRelevantChunks:
+    """get_relevant_chunks queries FAISS indices and returns deduplicated chunks."""
+
+    _CHUNK = {"source_file": "auth.py", "content": "def check_auth(): pass"}
+
+    @pytest.mark.unit
+    @patch("maposcal.generator.control_mapper.local_embedder")
+    @patch("maposcal.generator.control_mapper.faiss_index")
+    @patch("maposcal.generator.control_mapper.meta_store")
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_happy_path_returns_chunks(
+        self, _mock_exists, mock_meta_store, mock_faiss_index, mock_local_embedder
+    ):
+        mock_local_embedder.embed_one.return_value = [0.1, 0.2, 0.3]
+        mock_faiss_index.load_index.return_value = MagicMock()
+        mock_faiss_index.search_index.return_value = ([0], [0.9])
+        # load_metadata is called twice: once for chunk meta (list), once for summary
+        # meta (dict). The summary meta must be a dict to avoid .items() error.
+        mock_meta_store.load_metadata.side_effect = [
+            [self._CHUNK],  # chunk meta.json → list format
+            {},             # summary_meta.json → empty dict (no summaries)
+        ]
+        mock_meta_store.get_chunk_by_index.return_value = self._CHUNK
+
+        chunks = get_relevant_chunks("access control", "/fake/output")
+        assert isinstance(chunks, list)
+        assert len(chunks) > 0
+
+    @pytest.mark.unit
+    @patch("maposcal.generator.control_mapper.local_embedder")
+    @patch("pathlib.Path.exists", return_value=False)
+    def test_missing_required_index_raises(self, _mock_exists, mock_local_embedder):
+        # embed_one is called before Path.exists check, so it must be mocked too
+        mock_local_embedder.embed_one.return_value = [0.1, 0.2, 0.3]
+        with pytest.raises(FileNotFoundError):
+            get_relevant_chunks("access control", "/nonexistent/output")
+
+    @pytest.mark.unit
+    @patch("maposcal.generator.control_mapper.local_embedder")
+    @patch("maposcal.generator.control_mapper.faiss_index")
+    @patch("maposcal.generator.control_mapper.meta_store")
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_deduplication_by_source_file(
+        self, _mock_exists, mock_meta_store, mock_faiss_index, mock_local_embedder
+    ):
+        mock_local_embedder.embed_one.return_value = [0.1, 0.2, 0.3]
+        mock_faiss_index.load_index.return_value = MagicMock()
+        # Return the same index twice to simulate duplicates from the main index
+        mock_faiss_index.search_index.return_value = ([0, 0], [0.9, 0.9])
+        mock_meta_store.load_metadata.side_effect = [
+            [self._CHUNK],  # chunk meta.json → list format
+            {},             # summary_meta.json → empty dict
+        ]
+        mock_meta_store.get_chunk_by_index.return_value = self._CHUNK
+
+        chunks = get_relevant_chunks("access control", "/fake/output")
+        source_files = [c["source_file"] for c in chunks if "source_file" in c]
+        # auth.py should appear at most once after deduplication
+        assert source_files.count("auth.py") <= 1
+
+
+# ---------------------------------------------------------------------------
+# E. map_control — mocked LLM and chunks
+# ---------------------------------------------------------------------------
+
+class TestMapControl:
+    """map_control generates OSCAL implemented requirements with retry logic."""
+
+    def _make_llm_mock(self, query_return_value):
+        mock_llm_class = MagicMock()
+        mock_llm_instance = MagicMock()
+        mock_llm_class.return_value = mock_llm_instance
+        mock_llm_instance.query.return_value = query_return_value
+        return mock_llm_class, mock_llm_instance
+
+    @pytest.mark.unit
+    @patch("pathlib.Path.exists", return_value=False)
+    @patch("maposcal.generator.control_mapper.get_relevant_chunks", return_value=[])
+    @patch("maposcal.generator.control_mapper.LLMHandler")
+    def test_happy_path_returns_valid_structure(
+        self, mock_llm_class, _mock_chunks, _mock_exists
+    ):
+        mock_llm_instance = MagicMock()
+        mock_llm_class.return_value = mock_llm_instance
+        mock_llm_instance.query.return_value = json.dumps(VALID_LLM_CONTENT)
+
+        result = map_control(SAMPLE_CONTROL_DICT, "/fake/output")
+
+        assert result["control-id"] == "AC-1"
+        assert "uuid" in result
+        assert "props" in result
+        # Verify LLM content was merged in
+        status_prop = next(
+            p for p in result["props"] if p["name"] == "control-status"
+        )
+        assert status_prop["value"] == "applicable and inherently satisfied"
+
+    @pytest.mark.unit
+    @patch("pathlib.Path.exists", return_value=False)
+    @patch("maposcal.generator.control_mapper.get_relevant_chunks", return_value=[])
+    @patch("maposcal.generator.control_mapper.LLMHandler")
+    def test_retry_logic_succeeds_on_second_attempt(
+        self, mock_llm_class, _mock_chunks, _mock_exists
+    ):
+        mock_llm_instance = MagicMock()
+        mock_llm_class.return_value = mock_llm_instance
+
+        # Attempt 0: invalid content (missing explanation + description)
+        invalid_response = json.dumps({
+            "control-status": "not-a-valid-status",
+            "control-explanation": "x",
+            "control-configuration": [],
+            "statement-description": "x",
+        })
+        # Attempt 0 error prompt response (discarded by continue)
+        # Attempt 1: valid content
+        valid_response = json.dumps(VALID_LLM_CONTENT)
+
+        mock_llm_instance.query.side_effect = [
+            invalid_response,   # attempt 0 content prompt
+            invalid_response,   # attempt 0 error prompt (discarded)
+            valid_response,     # attempt 1 content prompt
+        ]
+
+        result = map_control(SAMPLE_CONTROL_DICT, "/fake/output")
+
+        assert result["control-id"] == "AC-1"
+        status_prop = next(
+            p for p in result["props"] if p["name"] == "control-status"
+        )
+        assert status_prop["value"] == "applicable and inherently satisfied"
+
+    @pytest.mark.unit
+    @patch("pathlib.Path.exists", return_value=False)
+    @patch("maposcal.generator.control_mapper.get_relevant_chunks", return_value=[])
+    @patch("maposcal.generator.control_mapper.LLMHandler")
+    def test_all_retries_exhausted_returns_template(
+        self, mock_llm_class, _mock_chunks, _mock_exists
+    ):
+        mock_llm_instance = MagicMock()
+        mock_llm_class.return_value = mock_llm_instance
+
+        # All responses are invalid so all retries are consumed
+        always_invalid = json.dumps({
+            "control-status": "bad-status",
+            "control-explanation": "x",
+            "control-configuration": [],
+            "statement-description": "x",
+        })
+        mock_llm_instance.query.return_value = always_invalid
+
+        result = map_control(SAMPLE_CONTROL_DICT, "/fake/output")
+
+        # Falls back to the structural template — must still be a valid dict
+        # with the control-id and required structural keys
+        assert isinstance(result, dict)
+        assert result["control-id"] == "AC-1"
+        assert "props" in result
+
+    @pytest.mark.unit
+    @patch("pathlib.Path.exists", return_value=False)
+    @patch("maposcal.generator.control_mapper.get_relevant_chunks", return_value=[])
+    @patch("maposcal.generator.control_mapper.LLMHandler")
+    def test_custom_llm_config_used(self, mock_llm_class, _mock_chunks, _mock_exists):
+        mock_llm_instance = MagicMock()
+        mock_llm_class.return_value = mock_llm_instance
+        mock_llm_instance.query.return_value = json.dumps(VALID_LLM_CONTENT)
+
+        llm_config = {"provider": "openai", "model": "gpt-4o", "temperature": 0.0}
+        result = map_control(SAMPLE_CONTROL_DICT, "/fake/output", llm_config=llm_config)
+
+        mock_llm_class.assert_called_once_with(provider="openai", model="gpt-4o")
+        assert result["control-id"] == "AC-1"

--- a/tests/llm/test_llm.py
+++ b/tests/llm/test_llm.py
@@ -6,6 +6,8 @@ import maposcal.llm.prompt_templates as prompt_templates
 
 
 class TestLLMHandler:
+    pytestmark = pytest.mark.unit
+
     @patch("maposcal.llm.llm_handler.tiktoken")
     @patch("maposcal.llm.llm_handler.OpenAI")
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
@@ -185,65 +187,73 @@ class TestLLMHandler:
 
 
 class TestPromptTemplates:
-    def test_build_service_overview_prompt(self):
-        context = "Service context"
-        prompt = prompt_templates.build_service_overview_prompt(context)
-        assert "Service Overview" in prompt
-        assert context in prompt
+    """Prompt template functions return non-empty strings containing expected substrings."""
 
-    def test_build_file_summary_prompt(self):
-        filename = "main.py"
-        file_content = "def foo(): pass"
-        prompt = prompt_templates.build_file_summary_prompt(filename, file_content)
-        assert filename in prompt
-        assert file_content in prompt
-        assert "Summary:" in prompt
+    _EVIDENCE_CHUNK = {
+        "chunk_type": "code",
+        "source_file": "main.py",
+        "start_line": 1,
+        "end_line": 10,
+        "content": "def foo(): pass",
+    }
 
-    def test_build_control_prompt(self):
-        prompt = prompt_templates.build_control_prompt(
-            control_id="AC-1",
-            control_name="Access Control",
-            control_description="desc",
-            evidence_chunks=[
-                {
-                    "chunk_type": "code",
-                    "source_file": "main.py",
-                    "start_line": 1,
-                    "end_line": 10,
-                    "content": "def foo(): pass",
-                }
-            ],
-            main_uuid="uuid1",
-            statement_uuid="uuid2",
-            security_overview="overview",
-        )
-        assert "AC-1" in prompt
-        assert "Access Control" in prompt
-        assert "overview" in prompt
-        assert "def foo(): pass" in prompt
-        assert "Generate the JSON now" in prompt
-
-    def test_build_critique_prompt(self):
-        implemented_requirements = [{"control-id": "AC-1"}]
-        prompt = prompt_templates.build_critique_prompt(
-            implemented_requirements, security_overview="overview"
-        )
-        assert "violations" in prompt
-        assert "overview" in prompt
-        assert "AC-1" in prompt
-
-    def test_build_revise_prompt(self):
-        implemented_requirements = [{"control-id": "AC-1"}]
-        violations = [{"path": "props[0]", "issue": "Missing"}]
-        prompt = prompt_templates.build_revise_prompt(
-            implemented_requirements, violations, security_overview="overview"
-        )
-        assert "violations" in prompt
-        assert "overview" in prompt
-        assert "AC-1" in prompt
-
-    def test_build_evaluate_prompt(self):
-        requirement = {"control-id": "AC-1"}
-        prompt = prompt_templates.build_evaluate_prompt(requirement)
-        assert "control-id" in prompt
-        assert "scores" in prompt or "Score" in prompt
+    @pytest.mark.parametrize("func,kwargs,expected_substrings", [
+        pytest.param(
+            prompt_templates.build_service_overview_prompt,
+            {"context": "Service context"},
+            ["Service Overview", "Service context"],
+            id="service_overview",
+        ),
+        pytest.param(
+            prompt_templates.build_file_summary_prompt,
+            {"filename": "main.py", "file_content": "def foo(): pass"},
+            ["main.py", "def foo(): pass", "Summary:"],
+            id="file_summary",
+        ),
+        pytest.param(
+            prompt_templates.build_control_prompt,
+            {
+                "control_id": "AC-1",
+                "control_name": "Access Control",
+                "control_description": "desc",
+                "evidence_chunks": [_EVIDENCE_CHUNK],
+                "main_uuid": "uuid1",
+                "statement_uuid": "uuid2",
+                "security_overview": "overview",
+            },
+            ["AC-1", "Access Control", "overview", "def foo(): pass", "Generate the JSON now"],
+            id="control_prompt",
+        ),
+        pytest.param(
+            prompt_templates.build_critique_prompt,
+            {
+                "implemented_requirements": [{"control-id": "AC-1"}],
+                "security_overview": "overview",
+            },
+            ["violations", "overview", "AC-1"],
+            id="critique",
+        ),
+        pytest.param(
+            prompt_templates.build_revise_prompt,
+            {
+                "implemented_requirements": [{"control-id": "AC-1"}],
+                "violations": [{"path": "props[0]", "issue": "Missing"}],
+                "security_overview": "overview",
+            },
+            ["violations", "overview", "AC-1"],
+            id="revise",
+        ),
+        pytest.param(
+            prompt_templates.build_evaluate_prompt,
+            {"requirement": {"control-id": "AC-1"}},
+            ["control-id", "scores"],
+            id="evaluate",
+        ),
+    ])
+    @pytest.mark.unit
+    def test_prompt_templates(self, func, kwargs, expected_substrings):
+        result = func(**kwargs)
+        assert isinstance(result, str)
+        assert len(result) > 0
+        for substring in expected_substrings:
+            assert substring in result

--- a/tests/test_inspectors.py
+++ b/tests/test_inspectors.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import mock_open, patch
 from maposcal.inspectors import inspect_lang_python, inspect_lang_golang
 
@@ -19,139 +20,153 @@ import (
 var apiKey = os.Getenv("API_KEY")
 """
 
+# ---------------------------------------------------------------------------
+# Parametrize helpers — one entry per language
+# ---------------------------------------------------------------------------
 
-def test_python_identify_imported_modules():
-    modules, network, fs, logging_mod, crypto = (
-        inspect_lang_python.identify_imported_modules(PYTHON_SAMPLE)
-    )
-    assert "os" in modules
-    assert "requests" in network
-    assert "logging" in logging_mod
-    assert "os" in fs
-    assert "logging" in modules
-    assert "requests" in modules
+INSPECTOR_PARAMS = [
+    pytest.param(
+        inspect_lang_python,
+        PYTHON_SAMPLE,
+        "fake.py",
+        "Python",
+        {
+            "in_modules": ["os", "logging", "requests"],
+            "in_network": ["requests"],
+            "in_fs": ["os"],
+            "in_logging": ["logging"],
+        },
+        id="python",
+    ),
+    pytest.param(
+        inspect_lang_golang,
+        GOLANG_SAMPLE,
+        "fake.go",
+        "Golang",
+        {
+            "in_modules": ["os"],
+            "in_network": ["net/http"],
+            "in_fs": ["os"],
+            "in_logging": ["log"],
+            "in_crypto": ["crypto/tls"],
+        },
+        id="golang",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Parametrized tests shared across both languages
+# ---------------------------------------------------------------------------
 
 
-def test_python_identify_imported_configuration_variables():
-    results = inspect_lang_python.identify_imported_configuration_variables(
-        PYTHON_SAMPLE
-    )
+@pytest.mark.parametrize("inspector,sample,filename,lang,expected", INSPECTOR_PARAMS)
+@pytest.mark.unit
+def test_identify_imported_modules(inspector, sample, filename, lang, expected):
+    modules, network, fs, logging_mod, crypto = inspector.identify_imported_modules(sample)
+    for m in expected.get("in_modules", []):
+        assert m in modules
+    for m in expected.get("in_network", []):
+        assert m in network
+    for m in expected.get("in_fs", []):
+        assert m in fs
+    for m in expected.get("in_logging", []):
+        assert m in logging_mod
+    for m in expected.get("in_crypto", []):
+        assert m in crypto
+
+
+@pytest.mark.parametrize("inspector,sample,filename,lang,expected", [
+    pytest.param(inspect_lang_python, PYTHON_SAMPLE, "fake.py", "Python", "API_KEY", id="python"),
+    pytest.param(inspect_lang_golang, GOLANG_SAMPLE, "fake.go", "Golang", "apiKey", id="golang"),
+])
+@pytest.mark.unit
+def test_identify_imported_configuration_variables(inspector, sample, filename, lang, expected):
+    results = inspector.identify_imported_configuration_variables(sample)
     assert any(
-        r["variable"] == "API_KEY" and r["method"].startswith("Environment")
+        r["variable"] == expected and r["method"].startswith("Environment")
         for r in results
     )
 
 
-def test_python_start_inspection():
-    with patch("builtins.open", mock_open(read_data=PYTHON_SAMPLE)):
-        result = inspect_lang_python.start_inspection("fake.py", None)
-    assert result["language"] == "Python"
-    assert "API_KEY" in str(result["configuration_settings"])
-    assert "requests" in str(result["loaded_modules"]["network_modules"])
-    assert "logging" in str(result["loaded_modules"]["logging_modules"])
-    assert "os" in str(result["loaded_modules"]["file_system_modules"])
+@pytest.mark.parametrize("inspector,sample,filename,lang,config_var,network,fs,log_mod", [
+    pytest.param(
+        inspect_lang_python, PYTHON_SAMPLE, "fake.py", "Python",
+        "API_KEY", "requests", "os", "logging",
+        id="python",
+    ),
+    pytest.param(
+        inspect_lang_golang, GOLANG_SAMPLE, "fake.go", "Golang",
+        "apiKey", "net/http", "os", "log",
+        id="golang",
+    ),
+])
+@pytest.mark.unit
+def test_start_inspection(inspector, sample, filename, lang, config_var, network, fs, log_mod):
+    with patch("builtins.open", mock_open(read_data=sample)):
+        result = inspector.start_inspection(filename, None)
+    assert result["language"] == lang
+    assert config_var in str(result["configuration_settings"])
+    assert network in str(result["loaded_modules"]["network_modules"])
+    assert log_mod in str(result["loaded_modules"]["logging_modules"])
+    assert fs in str(result["loaded_modules"]["file_system_modules"])
     assert "file_summary" in result
 
 
-def test_python_summarize_discovery_content():
-    with patch("builtins.open", mock_open(read_data=PYTHON_SAMPLE)):
-        result = inspect_lang_python.start_inspection("fake.py", None)
-    summary = inspect_lang_python.summarize_discovery_content(result)
-    assert "Python" in summary
+@pytest.mark.parametrize("inspector,sample,filename,lang", [
+    pytest.param(inspect_lang_python, PYTHON_SAMPLE, "fake.py", "Python", id="python"),
+    pytest.param(inspect_lang_golang, GOLANG_SAMPLE, "fake.go", "Golang", id="golang"),
+])
+@pytest.mark.unit
+def test_summarize_discovery_content(inspector, sample, filename, lang):
+    with patch("builtins.open", mock_open(read_data=sample)):
+        result = inspector.start_inspection(filename, None)
+    summary = inspector.summarize_discovery_content(result)
+    assert lang in summary
     assert "networking modules" in summary
     assert "File system access is expected" in summary
     assert "Logging capabilities are expected" in summary
 
 
-def test_golang_identify_imported_modules():
-    modules, network, fs, logging_mod, crypto = (
-        inspect_lang_golang.identify_imported_modules(GOLANG_SAMPLE)
-    )
-    assert "os" in modules
-    assert "net/http" in network
-    assert "log" in logging_mod
-    assert "os" in fs
-    assert "crypto/tls" in crypto
-
-
-def test_golang_identify_imported_configuration_variables():
-    results = inspect_lang_golang.identify_imported_configuration_variables(
-        GOLANG_SAMPLE
-    )
-    assert any(
-        r["variable"] == "apiKey" and r["method"].startswith("Environment")
-        for r in results
-    )
-
-
-def test_golang_start_inspection():
-    with patch("builtins.open", mock_open(read_data=GOLANG_SAMPLE)):
-        result = inspect_lang_golang.start_inspection("fake.go", None)
-    assert result["language"] == "Golang"
-    assert "apiKey" in str(result["configuration_settings"])
-    assert "net/http" in str(result["loaded_modules"]["network_modules"])
-    assert "log" in str(result["loaded_modules"]["logging_modules"])
-    assert "os" in str(result["loaded_modules"]["file_system_modules"])
-    assert "file_summary" in result
-
-
-def test_golang_summarize_discovery_content():
-    with patch("builtins.open", mock_open(read_data=GOLANG_SAMPLE)):
-        result = inspect_lang_golang.start_inspection("fake.go", None)
-    summary = inspect_lang_golang.summarize_discovery_content(result)
-    assert "Golang" in summary
-    assert "networking modules" in summary
-    assert "File system access is expected" in summary
-    assert "Logging capabilities are expected" in summary
-
-
-def test_python_path_truncation():
-    """Test that file paths are truncated when base_dir is provided."""
-    with patch("builtins.open", mock_open(read_data=PYTHON_SAMPLE)):
-        result = inspect_lang_python.start_inspection(
-            "/Users/test/code/project/file.py", "/Users/test/code/project"
+@pytest.mark.parametrize("inspector,sample,ext", [
+    pytest.param(inspect_lang_python, PYTHON_SAMPLE, "py", id="python"),
+    pytest.param(inspect_lang_golang, GOLANG_SAMPLE, "go", id="golang"),
+])
+@pytest.mark.unit
+def test_path_truncation(inspector, sample, ext):
+    with patch("builtins.open", mock_open(read_data=sample)):
+        result = inspector.start_inspection(
+            f"/Users/test/code/project/file.{ext}", "/Users/test/code/project"
         )
-    assert result["file_path"] == "file.py"
+    assert result["file_path"] == f"file.{ext}"
 
 
-def test_golang_path_truncation():
-    """Test that file paths are truncated when base_dir is provided."""
-    with patch("builtins.open", mock_open(read_data=GOLANG_SAMPLE)):
-        result = inspect_lang_golang.start_inspection(
-            "/Users/test/code/project/file.go", "/Users/test/code/project"
+@pytest.mark.parametrize("inspector,sample,ext", [
+    pytest.param(inspect_lang_python, PYTHON_SAMPLE, "py", id="python"),
+    pytest.param(inspect_lang_golang, GOLANG_SAMPLE, "go", id="golang"),
+])
+@pytest.mark.unit
+def test_path_no_truncation(inspector, sample, ext):
+    with patch("builtins.open", mock_open(read_data=sample)):
+        result = inspector.start_inspection(
+            f"/Users/test/code/project/file.{ext}", None
         )
-    assert result["file_path"] == "file.go"
+    assert result["file_path"] == f"/Users/test/code/project/file.{ext}"
 
 
-def test_python_path_no_truncation():
-    """Test that file paths are not truncated when base_dir is not provided."""
-    with patch("builtins.open", mock_open(read_data=PYTHON_SAMPLE)):
-        result = inspect_lang_python.start_inspection(
-            "/Users/test/code/project/file.py", None
-        )
-    assert result["file_path"] == "/Users/test/code/project/file.py"
+# ---------------------------------------------------------------------------
+# Language-specific tests (Python only — no Go equivalent)
+# ---------------------------------------------------------------------------
 
 
-def test_golang_path_no_truncation():
-    """Test that file paths are not truncated when base_dir is not provided."""
-    with patch("builtins.open", mock_open(read_data=GOLANG_SAMPLE)):
-        result = inspect_lang_golang.start_inspection(
-            "/Users/test/code/project/file.go", None
-        )
-    assert result["file_path"] == "/Users/test/code/project/file.go"
-
-
+@pytest.mark.unit
 def test_python_summarize_discovery_content_missing_keys():
-    """Test that summarize_discovery_content handles missing keys gracefully."""
-    # Create a result dict with missing loaded_modules keys
+    """summarize_discovery_content handles a result with no loaded_modules sub-keys."""
     incomplete_result = {
         "file_path": "test.py",
         "language": "Python",
-        "loaded_modules": {},  # Empty dict without required keys
-        "configuration_settings": []
+        "loaded_modules": {},
+        "configuration_settings": [],
     }
-
-    # This should not raise a KeyError
     summary = inspect_lang_python.summarize_discovery_content(incomplete_result)
     assert "Python" in summary
     assert "No networking capabilities have been detected" in summary
@@ -160,20 +175,18 @@ def test_python_summarize_discovery_content_missing_keys():
     assert "No configuration settings" in summary
 
 
+@pytest.mark.unit
 def test_python_summarize_discovery_content_partial_keys():
-    """Test that summarize_discovery_content handles partial keys gracefully."""
-    # Create a result dict with some missing keys
+    """summarize_discovery_content handles partial loaded_modules gracefully."""
     partial_result = {
         "file_path": "test.py",
         "language": "Python",
         "loaded_modules": {
             "network_modules": ["requests"],
-            # Missing other keys
+            # fs and logging keys deliberately absent
         },
-        "configuration_settings": []
+        "configuration_settings": [],
     }
-
-    # This should not raise a KeyError
     summary = inspect_lang_python.summarize_discovery_content(partial_result)
     assert "Python" in summary
     assert "networking modules shows the following being used for connectivity: ['requests']" in summary

--- a/tests/utils/test_metadata.py
+++ b/tests/utils/test_metadata.py
@@ -2,6 +2,7 @@
 Tests for metadata utilities.
 """
 
+from maposcal import __version__
 from maposcal.utils.metadata import (
     generate_metadata,
     inject_metadata_into_json,
@@ -29,7 +30,7 @@ class TestGenerateMetadata:
         assert info["command"] == "generate"
         assert "start_time" in info
         assert info["config_file"] is None
-        assert info["version"] == "0.1.0"  # Should match package version
+        assert info["version"] == __version__
 
     def test_generate_metadata_with_config_file(self):
         """Test metadata generation with config file."""
@@ -68,7 +69,7 @@ class TestGenerateMetadata:
         )
 
         # Should use the package version from __init__.py
-        assert metadata["generation_info"]["version"] == "0.1.0"
+        assert metadata["generation_info"]["version"] == __version__
 
 
 class TestInjectMetadataIntoJson:
@@ -252,7 +253,7 @@ This is the content."""
         assert info["base_url"] == "https://api.openai.com/v1"
         assert info["command"] == "summarize"
         assert info["config_file"] == "config.yaml"
-        assert info["version"] == "0.1.0"  # Should match package version
+        assert info["version"] == "0.1.0"
 
     def test_extract_metadata_from_markdown_without_metadata(self):
         """Test extracting metadata from markdown without metadata."""


### PR DESCRIPTION
## Summary

- **Fill `tests/generator/test_generator.py`** (was completely empty) with 46 tests covering the core generator module:
  - `parse_llm_response`: markdown fenced blocks, plain JSON, whitespace, malformed input, empty strings
  - `security_section_mapper` pure functions: `get_control_family`, `get_relevant_security_sections`, `parse_security_overview_sections`, `build_selective_security_overview_section`, `validate_security_overview_structure`
  - `validate_content_quality`: all validation paths
  - `get_relevant_chunks`: happy path, missing-files `FileNotFoundError`, deduplication (all with mocked FAISS/embedder)
  - `map_control`: happy path, retry-on-second-attempt, all-retries-exhausted fallback, custom LLM config

- **Parametrize `tests/test_inspectors.py`**: merge 6 duplicated Python/Go parallel test pairs into `@pytest.mark.parametrize`, keeping Python-specific edge-case tests standalone

- **Parametrize `tests/llm/test_llm.py`**: collapse 6 individual `TestPromptTemplates` methods into one parametrized test; add `pytestmark = pytest.mark.unit` to `TestLLMHandler`

- **`pyproject.toml`**: register `unit`, `integration`, `slow` markers; add `addopts = "--tb=short"`; add `filterwarnings` to suppress pydantic/transformers deprecation noise

## Test plan

- [ ] All 273 tests pass: `.venv/bin/pytest tests/ -v`
- [ ] New generator tests pass in isolation: `.venv/bin/pytest tests/generator/test_generator.py -v`
- [ ] Marker filtering works: `.venv/bin/pytest -m unit tests/` collects 76 tests
- [ ] No unknown marker warnings from pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)