### PR TITLE
Add Anthropic as an LLM provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ maposcal/.DS_Store
 maposcal/.DS_Store
 logs/
 *.log
+
+# Local config
+config.yaml

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ These improvements make MapOSCAL more user-friendly, accurate, and maintainable 
 - pip (Python package installer)
 
 ### Setup
-0. OpenAI API Key:
-This open source configuration currently only supports OpenAI's API functionality for the LLM-based operations.  You will need to configure your environmental variable "OPENAI_API_KEY" to have a valid API key.
+0. LLM API Key:
+MapOSCAL supports OpenAI, Google Gemini, and Anthropic as LLM providers. You will need to configure the appropriate environment variable for your chosen provider (e.g., `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `ANTHROPIC_API_KEY`). See [LLM Configuration](#llm-configuration-optional) for details.
 
 2. Clone the repository:
 ```bash
@@ -255,13 +255,15 @@ llm:
 
 - **OpenAI**: Any OpenAI model (e.g., `gpt-4`, `gpt-4-turbo`, `gpt-3.5-turbo`, `gpt-4o`, `gpt-4o-mini`)
 - **Gemini** (via OpenAI-compatible API): Any Gemini model (e.g., `gemini-2.0-flash`, `gemini-2.5-flash`, `gemini-1.5-pro`)
+- **Anthropic** (via OpenAI-compatible API): Any Anthropic model (e.g., `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`, `claude-opus-4-6`)
 
 **Environment Variables Required:**
 - For OpenAI: `OPENAI_API_KEY`
 - For Gemini: `GEMINI_API_KEY`
+- For Anthropic: `ANTHROPIC_API_KEY`
 
 **Optional Base URL Overrides:**
-- `OPENAI_BASE_URL`, `GEMINI_BASE_URL`
+- `OPENAI_BASE_URL`, `GEMINI_BASE_URL`, `ANTHROPIC_BASE_URL`
 
 **Setup Environment Variables:**
 1. Copy `env.example` to `.env`: `cp env.example .env`

--- a/env.example
+++ b/env.example
@@ -13,6 +13,10 @@ OPENAI_API_KEY=sk-your-openai-api-key-here
 # Get your API key from: https://makersuite.google.com/app/apikey
 GEMINI_API_KEY=your-gemini-api-key-here
 
+# Anthropic (via OpenAI-compatible API)
+# Get your API key from: https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+
 
 
 # =============================================================================
@@ -25,6 +29,9 @@ GEMINI_API_KEY=your-gemini-api-key-here
 # Gemini (default: https://generativelanguage.googleapis.com/v1beta/openai/)
 # GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
 
+# Anthropic (default: https://api.anthropic.com/v1/)
+# ANTHROPIC_BASE_URL=https://api.anthropic.com/v1/
+
 
 
 # =============================================================================
@@ -33,8 +40,8 @@ GEMINI_API_KEY=your-gemini-api-key-here
 
 # 1. Only set the API keys for the providers you plan to use
 # 2. You can use different providers for different commands:
-#    - analyze: Fast, cost-effective models (e.g., gpt-4o-mini)
-#    - summarize: High-quality models (e.g., gpt-4, gemini-2.5-flash)
+#    - analyze: Fast, cost-effective models (e.g., gpt-4o-mini, claude-haiku-4-5-20251001)
+#    - summarize: High-quality models (e.g., gpt-4, gemini-2.5-flash, claude-sonnet-4-6)
 #    - generate: High-quality models for OSCAL generation
 #    - evaluate: High-quality models for assessment
 
@@ -45,8 +52,8 @@ GEMINI_API_KEY=your-gemini-api-key-here
 #        model: "gpt-4o-mini"
 #        temperature: 0.1  # Low temperature for consistent analysis
 #      generate:
-#        provider: "gemini"
-#        model: "gemini-2.5-flash"
+#        provider: "anthropic"
+#        model: "claude-sonnet-4-6"
 #        temperature: 0.4  # Moderate temperature for creative generation
 #      evaluate:
 #        provider: "openai"

--- a/maposcal/llm/llm_handler.py
+++ b/maposcal/llm/llm_handler.py
@@ -88,7 +88,7 @@ class LLMHandler:
                 f"No API key found for {self.provider}. Please set the {self.api_key_env} environment variable."
             )
 
-        # Initialize OpenAI client (works for OpenAI, Azure, and Gemini via OpenAI-compatible API)
+        # Initialize OpenAI client (works for OpenAI, Azure, Gemini, and Anthropic via OpenAI-compatible API)
         self.client = OpenAI(
             api_key=api_key,
             base_url=base_url,

--- a/maposcal/settings.py
+++ b/maposcal/settings.py
@@ -12,6 +12,10 @@ LLM_PROVIDERS = {
         "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
         "api_key_env": "GEMINI_API_KEY",
     },
+    "anthropic": {
+        "base_url": "https://api.anthropic.com/v1/",
+        "api_key_env": "ANTHROPIC_API_KEY",
+    },
 }
 
 # Default LLM configurations for each command

--- a/tests/llm/test_llm.py
+++ b/tests/llm/test_llm.py
@@ -128,6 +128,28 @@ class TestLLMHandler:
 
     @patch("maposcal.llm.llm_handler.OpenAI")
     @patch("maposcal.llm.llm_handler.tiktoken")
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test-key"})
+    def test_llm_handler_anthropic_provider(self, mock_tiktoken, mock_openai):
+        """Test LLMHandler with Anthropic provider."""
+        mock_encoding = MagicMock()
+        mock_encoding.encode.return_value = [1, 2]
+        mock_tiktoken.get_encoding.return_value = mock_encoding
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+
+        handler = LLMHandler(provider="anthropic", model="claude-sonnet-4-6")
+
+        assert handler.provider == "anthropic"
+        assert handler.model == "claude-sonnet-4-6"
+        assert handler.base_url == "https://api.anthropic.com/v1/"
+        assert handler.api_key_env == "ANTHROPIC_API_KEY"
+        mock_openai.assert_called_with(
+            api_key="sk-ant-test-key",
+            base_url="https://api.anthropic.com/v1/",
+        )
+
+    @patch("maposcal.llm.llm_handler.OpenAI")
+    @patch("maposcal.llm.llm_handler.tiktoken")
     @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test-key"})
     def test_llm_handler_command_defaults(self, mock_tiktoken, mock_openai):
         """Test LLMHandler with command-specific defaults."""


### PR DESCRIPTION
Users using Anthropic's Claude models can now use them as the LLM provider for all MapOSCAL operations (analyze, summarize, generate, evaluate, k8s-process)

## What's changing?

- Added `anthropic` provider to `LLM_PROVIDERS` in `settings.py` with OpenAI-compatible base URL and `ANTHROPIC_API_KEY` env var
- Updated `llm_handler.py` comment to reflect Anthropic support
- Updated `env.example` with Anthropic API key, base URL override, and usage examples
- Updated `README.md` setup instructions, supported providers list, env vars, and base URL overrides
- Added `test_llm_handler_anthropic_provider` unit test

No handler code changes were needed - Anthropic's API is OpenAI-compatible, so the existing `OpenAI` client works with just a config entry.

## How Tested

- All 17 LLM tests pass including new Anthropic provider test
- Verified provider initializes with correct base URL and API key env var